### PR TITLE
Remove special chars (@) from JSON Field names

### DIFF
--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -3,8 +3,8 @@ map $http_x_forwarded_proto $fcgi_https {
   https on;
 }
 
-log_format json_php '{ "@timestamp": "$time_iso8601", '
-                  '"@fields": { '
+log_format json_php '{ "timestamp": "$time_iso8601", '
+                  '"fields": { '
                   '"x-forwarded-for": "$http_x_forwarded_for", '
                   '"remote_user": "$remote_user", '
                   '"body_bytes_sent": "$body_bytes_sent", '


### PR DESCRIPTION
Special characters (@, etc) are not parseable in Cloudwatch. We are removing them so that the logs can be parsed using Cloudwatch's native JSON parser.