### PR TITLE
Update Wordpress to 6.0.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -93,9 +93,9 @@ COPY config/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 
 # Add Bedrock
 # Sometime Bedrock don't have a release with the latest WP version and you have to use the dependabot commit
-# RUN curl -L -o wordpress.tar.gz https://github.com/roots/bedrock/archive/f0dc31cda0e97aa1ac131d14a615c80feff2a12a.tar.gz  && tar --strip=1 -xzvf wordpress.tar.gz && rm wordpress.tar.gz && \
+RUN curl -L -o wordpress.tar.gz https://github.com/roots/bedrock/archive/84133b258efabbcbbd258137fd199fd1f742f3d6.tar.gz  && tar --strip=1 -xzvf wordpress.tar.gz && rm wordpress.tar.gz && \
 # Use the next one when there's a Bedrock release
-RUN curl -L https://github.com/roots/bedrock/archive/refs/tags/1.19.3.tar.gz | tar -xzv --strip=1 && \
+# RUN curl -L https://github.com/roots/bedrock/archive/refs/tags/1.19.3.tar.gz | tar -xzv --strip=1 && \
     composer install --no-dev
 
 RUN chown -R www-data.www-data /var/www/html/web/app/uploads/


### PR DESCRIPTION
As bedrock doesn't have a release for WP 6.0.1 at the moment, I've commented out the Line:98 and using Line:96 instead.