### PR TITLE
Update Wordpress 6.5.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.1-fpm-alpine
+FROM php:8.1-fpm-alpine3.19
 LABEL Maintainer="Ocasta" \
       Description="Nginx PHP8.1 Wordpress Bedrock"
 
@@ -86,7 +86,7 @@ COPY config/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 # Sometime Bedrock don't have a release with the latest WP version and you have to use the dependabot commit
 # RUN curl -L -o wordpress.tar.gz https://github.com/roots/bedrock/archive/84133b258efabbcbbd258137fd199fd1f742f3d6.tar.gz  && tar --strip=1 -xzvf wordpress.tar.gz && rm wordpress.tar.gz && \
 # Use the next one when there's a Bedrock release
-RUN curl -L https://github.com/roots/bedrock/archive/refs/tags/1.24.1.tar.gz | tar -xzv --strip=1 && \
+RUN curl -L https://github.com/roots/bedrock/archive/refs/tags/1.24.2.tar.gz | tar -xzv --strip=1 && \
     composer install --no-dev
 
 COPY scripts/install-language.sh /usr/local/bin/install-language.sh


### PR DESCRIPTION
The Alpine version was downgraded to 3.19 because of an error with php81-xml.